### PR TITLE
Support encryption of very large files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A small collection of Clojure functions to provide basic GPG keypair generation,
 
 ## Usage
 
-Leiningen coordinates: `[thi.ng/crypto "0.1.0-SNAPSHOT"]`
+Leiningen coordinates: `[bilus/crypto "0.1.1-SNAPSHOT"]`
 
 ```clojure
 (require '[thi.ng.crypto.core :refer :all])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bilus/crypto "0.1.2"
+(defproject bilus/crypto "0.1.3"
   :description  "Small Clojure lib to provide basic GPG keypair generation, encryption & decryption facilities"
   :url          "https://github.com/thi-ng/crypto"
   :license      {:name "Apache Software License 2.0"
@@ -7,5 +7,5 @@
   :scm          {:name "git"
                  :url "git@github.com:thi-ng/crypto.git"}
   :dependencies [[org.clojure/clojure "1.6.0"]]                 
-  :profiles {:provided {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.52"]]}
-             :dev      {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.52"]]}})
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.52"]]}
+             :dev      {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.52"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bilus/crypto "0.1.1"
+(defproject bilus/crypto "0.1.2"
   :description  "Small Clojure lib to provide basic GPG keypair generation, encryption & decryption facilities"
   :url          "https://github.com/thi-ng/crypto"
   :license      {:name "Apache Software License 2.0"
@@ -7,5 +7,5 @@
   :scm          {:name "git"
                  :url "git@github.com:thi-ng/crypto.git"}
   :dependencies [[org.clojure/clojure "1.6.0"]]                 
-  :profiles {:provided {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.50"]]}
-             :dev      {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.50"]]}})
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.52"]]}
+             :dev      {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.52"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bilus/crypto "0.1.3"
+(defproject bilus/crypto "0.1.4"
   :description  "Small Clojure lib to provide basic GPG keypair generation, encryption & decryption facilities"
   :url          "https://github.com/thi-ng/crypto"
   :license      {:name "Apache Software License 2.0"
@@ -7,5 +7,5 @@
   :scm          {:name "git"
                  :url "git@github.com:thi-ng/crypto.git"}
   :dependencies [[org.clojure/clojure "1.6.0"]]                 
-  :profiles {:provided {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.52"]]}
-             :dev      {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.52"]]}})
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.50"]]}
+             :dev      {:dependencies [[org.bouncycastle/bcpg-jdk15on "1.50"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject thi.ng/crypto "0.1.0-SNAPSHOT"
+(defproject bilus/crypto "0.1.1-SNAPSHOT"
   :description  "Small Clojure lib to provide basic GPG keypair generation, encryption & decryption facilities"
   :url          "https://github.com/thi-ng/crypto"
   :license      {:name "Apache Software License 2.0"
@@ -6,5 +6,6 @@
                  :distribution :repo}
   :scm          {:name "git"
                  :url "git@github.com:thi-ng/crypto.git"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.bouncycastle/bcpg-jdk15on "1.51"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]                 
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.50"]]}
+             :dev      {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.50"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bilus/crypto "0.1.1-SNAPSHOT"
+(defproject bilus/crypto "0.1.1"
   :description  "Small Clojure lib to provide basic GPG keypair generation, encryption & decryption facilities"
   :url          "https://github.com/thi-ng/crypto"
   :license      {:name "Apache Software License 2.0"


### PR DESCRIPTION
`encrypt-file` and `encrypt-stream` triggers an Out of memory error for very large files. After the patch it no longer zips and encrypts whole files in a memory buffer; it uses streams instead.
